### PR TITLE
don't need attn weight in decoder

### DIFF
--- a/torchscale/architecture/decoder.py
+++ b/torchscale/architecture/decoder.py
@@ -462,7 +462,7 @@ class Decoder(nn.Module):
         return x, {
             "inner_states": inner_states,
             "l_aux": l_aux,
-            "attn": [layer_attn.mean(dim=0)],
+            "attn": None,
         }
 
     def output_layer(self, features):


### PR DESCRIPTION
Attention weight was originally designed for alignment models, so it is not necessary to include it in torchscale. 