### PR TITLE
fix a bug that overrides the default constructed output_projection

### DIFF
--- a/torchscale/architecture/decoder.py
+++ b/torchscale/architecture/decoder.py
@@ -260,8 +260,6 @@ class Decoder(nn.Module):
         else:
             self.layer_norm = None
 
-        self.output_projection = output_projection
-
         self.self_attn_relative_position = None
         self.cross_attn_relative_position = None
 


### PR DESCRIPTION
Fixes a bug that overrides the default constructed output_projection when `None` is passed in.

L228-235 

```
 if (
     output_projection is None
     and not args.no_output_layer
     and args.vocab_size > 0
 ):
     self.output_projection = self.build_output_projection(args)
 else:
     self.output_projection = output_projection
```
seems to already handle this properly. 

This PR removes a line that overrides the above unnecessarily. 