### PR TITLE
add basic test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f setup.py ]; then pip install .; fi
+    - name: Install pytest
+      run: |
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest tests/


### PR DESCRIPTION
Currently, the `test_encoder_decoder.py` in the `tests` directory fails its tests because the `EncoderDecoderConfig` class lacks the `normalize_output` element. Please fix this bug and update the code so that it passes the tests defined in `workflows/test.yml`.