### PR TITLE
Adding sqrt in the recurrent_forward of retnet to make it consistent with parallel_forward

### DIFF
--- a/torchscale/component/multiscale_retention.py
+++ b/torchscale/component/multiscale_retention.py
@@ -105,7 +105,7 @@ class MultiScaleRetention(nn.Module):
             prev_kv = incremental_state["prev_key_value"]
             prev_scale = incremental_state["scale"]
             scale = prev_scale * decay + 1
-            kv = prev_kv * (1 - 1 / scale).view(self.num_heads, 1, 1) + kv / scale.view(self.num_heads, 1, 1)
+            kv = prev_kv * (prev_scale.sqrt() * decay / scale.sqrt()).view(self.num_heads, 1, 1) + kv / scale.sqrt().view(self.num_heads, 1, 1)
             # kv = prev_kv * decay.view(self.num_heads, 1, 1) + kv
         else:
             scale = torch.ones_like(decay)


### PR DESCRIPTION
Adding sqrt in the recurrent_forward of retnet can avoid numerical underflow thus improving consistency and performance. https://github.com/microsoft/torchscale/issues/47