### PR TITLE
Fix No module named 'torch._six'

### DIFF
--- a/examples/longvit/utils.py
+++ b/examples/longvit/utils.py
@@ -21,7 +21,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
-from torch._six import inf
+from torch import inf
 # from torchmetrics import Metric
 from tensorboardX import SummaryWriter
 


### PR DESCRIPTION
This is a simple fix to the issue of pytorch no longer has torch._six.